### PR TITLE
Fixes: Undefined variable: configcontent

### DIFF
--- a/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
+++ b/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
@@ -202,6 +202,8 @@ class WebserverSkeleton extends AbstractSkeleton
         $aliases = $project["aliases"];
         $aliases[] = $project["name"] . "." . $hostmachine;
         $aliases[] = "www." .$project["name"] . "." . $hostmachine;
+        
+        $configcontent = '';
 
         if ($this->app["config"]["webserver"]["engine"] == 'nginx'){
             $this->prepareNginxDirectories($project);
@@ -230,7 +232,7 @@ class WebserverSkeleton extends AbstractSkeleton
             }
             $serverAlias .= "\n";
             $this->fileSystemProvider->writeProtectedFile($this->fileSystemProvider->getProjectConfigDirectory($project["name"]) . "/apache.d/05aliases", $serverAlias);
-            $configcontent = "";
+ 
             /** @var \SplFileInfo $config */
             foreach ($this->fileSystemProvider->getProjectApacheConfigs($project) as $config) {
                 $configcontent .= "\n#BEGIN " . $config->getRealPath() . "\n\n";


### PR DESCRIPTION
Fixes:

```
PHP Notice:  Undefined variable: configcontent in /opt/skylab/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php on line 217
PHP Stack trace:
PHP   1. {main}() /opt/skylab/skylab:0
PHP   2. Cilex\Application->run() /opt/skylab/skylab:36
PHP   3. Symfony\Component\Console\Application->run() /opt/skylab/vendor/cilex/cilex/src/Cilex/Application.php:66
PHP   4. Symfony\Component\Console\Application->doRun() /opt/skylab/vendor/symfony/console/Symfony/Component/Console/Application.php:124
PHP   5. Symfony\Component\Console\Application->doRunCommand() /opt/skylab/vendor/symfony/console/Symfony/Component/Console/Application.php:193
PHP   6. Symfony\Component\Console\Command\Command->run() /opt/skylab/vendor/symfony/console/Symfony/Component/Console/Application.php:889
PHP   7. Kunstmaan\Skylab\Command\AbstractCommand->execute() /opt/skylab/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:252
PHP   8. Kunstmaan\Skylab\Command\MaintenanceCommand->doExecute() /opt/skylab/src/Kunstmaan/Skylab/Command/AbstractCommand.php:24
PHP   9. Kunstmaan\Skylab\Provider\FileSystemProvider->projectsLoop() /opt/skylab/src/Kunstmaan/Skylab/Command/MaintenanceCommand.php:50
PHP  10. Kunstmaan\Skylab\Command\MaintenanceCommand->Kunstmaan\Skylab\Command\{closure}() /opt/skylab/src/Kunstmaan/Skylab/Provider/FileSystemProvider.php:168
PHP  11. Kunstmaan\Skylab\Provider\SkeletonProvider->skeletonLoop() /opt/skylab/src/Kunstmaan/Skylab/Command/MaintenanceCommand.php:49
PHP  12. Kunstmaan\Skylab\Command\MaintenanceCommand->Kunstmaan\Skylab\Command\{closure}() /opt/skylab/src/Kunstmaan/Skylab/Provider/SkeletonProvider.php:109
PHP  13. Kunstmaan\Skylab\Skeleton\WebserverSkeleton->maintenance() /opt/skylab/src/Kunstmaan/Skylab/Command/MaintenanceCommand.php:48

Notice: Undefined variable: configcontent in /opt/skylab/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php on line 217
```
