### PR TITLE
Warning when project will not be in the hosts file

### DIFF
--- a/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
+++ b/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
@@ -103,10 +103,13 @@ class WebserverSkeleton extends AbstractSkeleton
     private function writeHostFile()
     {
         $hostlines = array();
-        $this->fileSystemProvider->projectsLoop(function ($project) use (&$hostlines) {
-            if (array_key_exists($this->getName(), $project["skeletons"])) {
-                $hostlines[] = $this->app["config"]["webserver"]["localip"] . " " . $project["name"] . "." . $this->app["config"]["webserver"]["hostmachine"] . " www." . $project["name"] . "." . $this->app["config"]["webserver"]["hostmachine"] . "\n";
+        $dialogProvider = $this->dialogProvider;
+        $this->fileSystemProvider->projectsLoop(function ($project) use (&$hostlines, $dialogProvider) {
+            if (!array_key_exists($this->getName(), $project["skeletons"])) {
+                $dialogProvider->logWarning("Project " . $project["name"] . " will not be accessible because skeleton '" . $this->getName() . "' was not applied");
+                return;
             }
+            $hostlines[] = $this->app["config"]["webserver"]["localip"] . " " . $project["name"] . "." . $this->app["config"]["webserver"]["hostmachine"] . " www." . $project["name"] . "." . $this->app["config"]["webserver"]["hostmachine"] . "\n";
         });
         $this->dialogProvider->logTask("Updating the /etc/hosts file");
         $hostsfile = file("/etc/hosts");


### PR DESCRIPTION
Hard one to figure debug, but when a project has only the nginx skeleton applied and you have apache the project will not be in the hosts file (even tough it will get an apache config).