### PR TITLE
Can't access sentry ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+ * Enable sentry in developer mode
+
 0.0.11 / 2015-03-30
 ==================
 

--- a/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
+++ b/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
@@ -116,9 +116,6 @@ class WebserverSkeleton extends AbstractSkeleton
             }
             $hostlines[] = $this->app["config"]["webserver"]["localip"] . " " . $project["name"] . "." . $this->app["config"]["webserver"]["hostmachine"] . " www." . $project["name"] . "." . $this->app["config"]["webserver"]["hostmachine"] . "\n";
         });
-        if ($this->app["config"]["develmode"]) {
-            $hostlines[] = $this->app["config"]["webserver"]["localip"] . " app.getsentry.com  #This is a workarround for disabling sentry logging in this development environment";
-        }
         $this->dialogProvider->logTask("Updating the /etc/hosts file");
         $hostsfile = file("/etc/hosts");
         $resultLines = array();


### PR DESCRIPTION
I ran ```skylab maintenance --quick``` and now I can no longer access sentry errors in a browser.

Checking /etc/hosts I see it app.getsentry.com is added with a localhost entry (127.0.0.1). Can this be reverted?