### PR TITLE
Fix MySQL backup for Drupal sites

### DIFF
--- a/src/Kunstmaan/Skylab/Skeleton/MySQLSkeleton.php
+++ b/src/Kunstmaan/Skylab/Skeleton/MySQLSkeleton.php
@@ -100,7 +100,7 @@ class MySQLSkeleton extends AbstractSkeleton
         $this->processProvider->executeSudoCommand("echo 'SET autocommit=0;' > " . $backupDir . "/mysql.dmp");
         $this->processProvider->executeSudoCommand("echo 'SET unique_checks=0;' >> " . $backupDir . "/mysql.dmp");
         $this->processProvider->executeSudoCommand("echo 'SET foreign_key_checks=0;' >> " . $backupDir . "/mysql.dmp");
-        $this->processProvider->executeSudoCommand("mysqldump --ignore-table=" . $project["mysqldbname"] . ".sessions --skip-opt --add-drop-table --add-locks --create-options --disable-keys --single-transaction --skip-extended-insert --quick --set-charset -u " . $project["mysqluser"] . " -p" . $project["mysqlpass"] . " " . $project["mysqldbname"] . " >> " . $backupDir . "/mysql.dmp");
+        $this->processProvider->executeSudoCommand("mysqldump --skip-opt --add-drop-table --add-locks --create-options --disable-keys --single-transaction --skip-extended-insert --quick --set-charset -u " . $project["mysqluser"] . " -p" . $project["mysqlpass"] . " " . $project["mysqldbname"] . " >> " . $backupDir . "/mysql.dmp");
         $this->processProvider->executeSudoCommand("echo 'COMMIT;' >> " . $backupDir . "/mysql.dmp");
         $this->processProvider->executeSudoCommand("echo 'SET autocommit=1;' >> " . $backupDir . "/mysql.dmp");
         $this->processProvider->executeSudoCommand("echo 'SET unique_checks=1;' >> " . $backupDir . "/mysql.dmp");


### PR DESCRIPTION
When Drupal sites don't have a sessions table, they will just crash with a cryptic "The website encountered an unexpected error. Please try again later." error message.

Finding out what the actual root cause is takes lots of time (nothing appears in the server logs, you have to check the Drupal watchdog table to actually see what causes the issue).