### PR TITLE
Make sure the symfony cron tasks run with the correct environment

### DIFF
--- a/templates/execute/snippets/cron.yml
+++ b/templates/execute/snippets/cron.yml
@@ -1,0 +1,2 @@
+steps:
+  - if [ -f "app/config/anacrontab" ]; then sed -i -E "s/--env=[a-z]+/%deploy_symfony_env%/" app/config/anacrontab; fi

--- a/templates/execute/symfony.yml
+++ b/templates/execute/symfony.yml
@@ -20,6 +20,7 @@ build:
   - resource: snippets/gulpgrunt.yml
   - resource: snippets/assets.yml
   - resource: snippets/appdotphpfix.yml
+  - resource: snippets/cron.yml
 
 after_build_success:
   - resource: snippets/package-build.yml


### PR DESCRIPTION
For the moment, all symfony cronjobs run with the `prod`environment.
With this change they will run with the correct symfony environment.