### PR TITLE
Fix cache issue that occurs after you upgrade several composer packages and deploy again

### DIFF
--- a/templates/execute/symfony.yml
+++ b/templates/execute/symfony.yml
@@ -2,6 +2,7 @@
 before_build:
   - steps:
     - mkdir -p app/cache
+    - rm -rf app/cache/*
     - if [ "yes" = "%fetch_mysql%" ] && [ "yes" = "%run_mysql%" ]; then ssh-keyscan -p %dbsource_port% %dbsource_server% >> %home%/.ssh/known_hosts; fi
     - if [ "yes" = "%fetch_mysql%" ] && [ "yes" = "%run_mysql%" ]; then scp -P %dbsource_port% "%dbsource_server%:/home/projects/%dbsource_project%/backup/mysql.dmp.gz" app/cache/mysql.dmp.gz; fi
     - if [ "yes" = "%run_mysql%" ]; then echo "DROP DATABASE IF EXISTS %database_name%" | mysql -u "root" -p%mysql_root_password% | true; fi


### PR DESCRIPTION
Example deploy log:

```
...
  - Installing willdurand/geocoder-bundle (3.1.0)
    Loading from cache

  - Removing elao/web-profiler-extra-bundle (dev-master 8090ced)
  - Installing elao/web-profiler-extra-bundle (dev-master 573effd)
    Loading from cache

  - Removing endroid/twitter-bundle (dev-master c6c0c6d)
  - Installing endroid/twitter-bundle (dev-master 2c19898)
    Downloading

  - Removing friendsofsymfony/user-bundle (dev-master 808672b)
  - Installing friendsofsymfony/user-bundle (dev-master d5b28c3)
    Loading from cache

Generating optimized autoload files
> Incenteev\ParameterHandler\ScriptHandler::buildParameters
Updating the "app/config/parameters.yml" file
> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::buildBootstrap
> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache


                                                                                     
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]         
  You have requested a non-existent service "kunstmaan_admin.domain_configuration".  
                                                                                     


Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the post-install-cmd event terminated with an exception


                                                                             
  [RuntimeException]                                                         
  An error occurred when executing the "'cache:clear --no-warmup'" command.  
                                                                             


install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-plugins] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--ignore-platform-reqs] [packages1] ... [packagesN]


 35.05s
#0 /opt/skylab/src/Kunstmaan/Skylab/Provider/ProcessProvider.php(91): Kunstmaan\Skylab\Provider\DialogProvider->logError('Loading compose...')
#1 /opt/skylab/src/Kunstmaan/Skylab/Provider/ProcessProvider.php(34): Kunstmaan\Skylab\Provider\ProcessProvider->performCommand('if [ -f "compos...', false, Object(Closure), Array)
#2 /opt/skylab/src/Kunstmaan/Skylab/Command/ExecuteCommand.php(67): Kunstmaan\Skylab\Provider\ProcessProvider->executeCommand('if [ -f "compos...', false, Object(Closure), Array)
#3 /opt/skylab/src/Kunstmaan/Skylab/Command/ExecuteCommand.php(166): Kunstmaan\Skylab\Command\ExecuteCommand->runStep('build', Array, 'production', 'after_build_suc...')
#4 /opt/skylab/src/Kunstmaan/Skylab/Command/AbstractCommand.php(46): Kunstmaan\Skylab\Command\ExecuteCommand->doExecute()
#5 /opt/skylab/vendor/symfony/console/Command/Command.php(259): Kunstmaan\Skylab\Command\AbstractCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /opt/skylab/vendor/symfony/console/Application.php(878): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /opt/skylab/vendor/symfony/console/Application.php(195): Symfony\Component\Console\Application->doRunCommand(Object(Kunstmaan\Skylab\Command\ExecuteCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /opt/skylab/vendor/symfony/console/Application.php(126): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /opt/skylab/vendor/cilex/cilex/src/Cilex/Application.php(66): Symfony\Component\Console\Application->run()
#10 /opt/skylab/skylab(46): Cilex\Application->run()
#11 {main}#0 /opt/skylab/src/Kunstmaan/Skylab/Provider/ProcessProvider.php(91): Kunstmaan\Skylab\Provider\DialogProvider->logError('Loading compose...')
#1 /opt/skylab/src/Kunstmaan/Skylab/Provider/ProcessProvider.php(34): Kunstmaan\Skylab\Provider\ProcessProvider->performCommand('if [ -f "compos...', false, Object(Closure), Array)
#2 /opt/skylab/src/Kunstmaan/Skylab/Command/ExecuteCommand.php(67): Kunstmaan\Skylab\Provider\ProcessProvider->executeCommand('if [ -f "compos...', false, Object(Closure), Array)
#3 /opt/skylab/src/Kunstmaan/Skylab/Command/ExecuteCommand.php(166): Kunstmaan\Skylab\Command\ExecuteCommand->runStep('build', Array, 'production', 'after_build_suc...')
#4 /opt/skylab/src/Kunstmaan/Skylab/Command/AbstractCommand.php(46): Kunstmaan\Skylab\Command\ExecuteCommand->doExecute()
#5 /opt/skylab/vendor/symfony/console/Command/Command.php(259): Kunstmaan\Skylab\Command\AbstractCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /opt/skylab/vendor/symfony/console/Application.php(878): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /opt/skylab/vendor/symfony/console/Application.php(195): Symfony\Component\Console\Application->doRunCommand(Object(Kunstmaan\Skylab\Command\ExecuteCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /opt/skylab/vendor/symfony/console/Application.php(126): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /opt/skylab/vendor/cilex/cilex/src/Cilex/Application.php(66): Symfony\Component\Console\Application->run()
#10 /opt/skylab/skylab(46): Cilex\Application->run()
#11 {main}
```