### PR TITLE
Do npm install before composer install

### DIFF
--- a/templates/execute/symfony.yml
+++ b/templates/execute/symfony.yml
@@ -13,10 +13,10 @@ before_build:
     - if [ "yes" = "%fetch_mysql%" ] && [ "yes" = "%run_mysql%" ]; then zcat "app/cache/mysql.dmp.gz" | mysql "%database_name%" -u "root" -p%mysql_root_password%; fi
 
 build:
+  - resource: snippets/npm.yml
   - resource: snippets/composer.yml
   - resource: snippets/doctrine-build.yml
   - resource: snippets/bundler.yml
-  - resource: snippets/npm.yml
   - resource: snippets/bower.yml
   - resource: snippets/gulpgrunt.yml
   - resource: snippets/assets.yml


### PR DESCRIPTION
This way we can use npm dependencies for assets (needed in assets:install for some new style projects)