### PR TITLE
set owner and permissions in alphabetical order

### DIFF
--- a/src/Kunstmaan/Skylab/Provider/PermissionsProvider.php
+++ b/src/Kunstmaan/Skylab/Provider/PermissionsProvider.php
@@ -95,8 +95,10 @@ class PermissionsProvider extends AbstractProvider
      */
     public function applyOwnership(\ArrayObject $project)
     {
-        /** @var PermissionDefinition $pd */
-        foreach ($project["permissions"] as $pd) {
+		$permissions_sorted = new \ArrayObject($project["permissions"]);
+		$permissions_sorted->ksort();
+		/** @var PermissionDefinition $pd */
+		foreach ($permissions_sorted as $pd) {
             $thePath = $this->fileSystemProvider->getProjectDirectory($project["name"]) . $pd->getPath();
             if (!$pd->getOwnership()) {
                 $this->dialogProvider->logNotice("No ownership information for " . $thePath . ", do not chown");
@@ -136,10 +138,12 @@ class PermissionsProvider extends AbstractProvider
                 $this->processProvider->executeSudoCommand('chmod -R 700 ' . $this->fileSystemProvider->getProjectDirectory($project["name"]) . '/.ssh/');
             }
         } else {
+            $permissions_sorted = new \ArrayObject($project["permissions"]);
+            $permissions_sorted->ksort();
             /** @var PermissionDefinition $pd */
-            foreach ($project["permissions"] as $pd) {
+            foreach ($permissions_sorted as $pd) {
+                $path = $this->fileSystemProvider->getProjectDirectory($project["name"]) . $pd->getPath();
                 foreach ($pd->getAcl() as $acl) {
-                    $path = $this->fileSystemProvider->getProjectDirectory($project["name"]) . $pd->getPath();
                     if (file_exists($path)) {
                         $this->processProvider->executeSudoCommand('setfacl ' . $this->projectConfigProvider->searchReplacer($acl, $project) . ' ' . $path, true);
                     } else {


### PR DESCRIPTION
When running `skylab permissions my_project`, it looks like the folders defined in `permissions.xml` are iterated in random order to set the permissions.

My experience:

- For the same user, I set permissions for folders "/", and "/site". These folders are defined in this order the permissions.xml.

```xml
  <var name="/site">
    <item value="-R -m u:@config.wwwuser@:r-X"/>
   <item value="-R -m d:u:@config.wwwuser@:r-X"/>
    (...)
  </var>
  <var name="/site/wp-content">
    <item value="-R -m u:@config.wwwuser@:rwX"/>
    <item value="-R -m d:u:@config.wwwuser@:rwX"/>
    (...)
  </var>
```

- I run `skylab permissions my_project`

Result of `getfacl` on my_project/site/wp-content:
```
user:www-data:r-x
default:user:www-data:r-x
(...)
```

This behavior is not consistent for all projects. That's why I suppose the folders are just picked in a random order for applying the permissions. In this case: first permissions are set for "/site", which are later on replaced by the -R permissions on "/".
In my opinion, `skylab permissions` should honor the order in which the folders are defined in the xml. Or better: alphabetical order of the folders. This defines a clear rule that allow for overriding ACL's in subfolders.

This patch does just that.