### PR TITLE
Restrict permissions more in web/uploads folder

### DIFF
--- a/templates/apache/apache.d/10permissions.conf.twig
+++ b/templates/apache/apache.d/10permissions.conf.twig
@@ -1,4 +1,4 @@
-<Directory @config.projectsdir@@project.name@/data/current >
+<Directory @config.projectsdir@@project.name@/data/current>
   Options -Indexes +MultiViews +Includes +FollowSymLinks
   AllowOverride All
   <IfVersion < 2.4>
@@ -8,4 +8,9 @@
   <IfVersion >= 2.4>
     Require all granted
   </IfVersion>
+</Directory>
+
+<Directory @config.projectsdir@@project.name@/data/current/web/uploads/*>
+  AllowOverride None
+  php_flag engine off
 </Directory>

--- a/templates/symfony/apache.d/10permissions.conf.twig
+++ b/templates/symfony/apache.d/10permissions.conf.twig
@@ -1,4 +1,4 @@
-<Directory @config.projectsdir@@project.name@/data/current/web >
+<Directory @config.projectsdir@@project.name@/data/current/web>
   Options -Indexes +MultiViews +Includes +FollowSymLinks
   AllowOverride All
   <IfVersion < 2.4>
@@ -8,4 +8,9 @@
   <IfVersion >= 2.4>
     Require all granted
   </IfVersion>
+</Directory>
+
+<Directory @config.projectsdir@@project.name@/data/current/web/uploads/*>
+  AllowOverride None
+  php_flag engine off
 </Directory>


### PR DESCRIPTION
Prevent .htaccesses uploaded by users from overriding the root .htaccess in sub folders  and prevent php files from being executed in uploads folder