### PR TITLE
[Apache]: remove php_flag and use filesmatch

### DIFF
--- a/templates/apache/apache.d/10permissions.conf.twig
+++ b/templates/apache/apache.d/10permissions.conf.twig
@@ -12,5 +12,7 @@
 
 <Directory @config.projectsdir@@project.name@/data/current/web/uploads/*>
   AllowOverride None
-  php_flag engine off
+  <FilesMatch \.(?i:php)$>
+    Deny from all
+  </FilesMatch>
 </Directory>

--- a/templates/symfony/apache.d/10permissions.conf.twig
+++ b/templates/symfony/apache.d/10permissions.conf.twig
@@ -12,5 +12,7 @@
 
 <Directory @config.projectsdir@@project.name@/data/current/web/uploads/*>
   AllowOverride None
-  php_flag engine off
+  <FilesMatch \.(?i:php)$>
+    Deny from all
+  </FilesMatch>
 </Directory>


### PR DESCRIPTION
When using php-fpm, the php_flag will not work.