### PR TITLE
[Permissions]: cast string to integer for PHP7.1

### DIFF
--- a/src/Kunstmaan/Skylab/Provider/PermissionsProvider.php
+++ b/src/Kunstmaan/Skylab/Provider/PermissionsProvider.php
@@ -61,7 +61,7 @@ class PermissionsProvider extends AbstractProvider
     {
         if (!$this->isUser($userName)) {
             if (PHP_OS == "Darwin") {
-                $maxid = $this->processProvider->executeSudoCommand("dscl . list /Users UniqueID | awk '{print $2}' | sort -ug | tail -1");
+                $maxid = (int) $this->processProvider->executeSudoCommand("dscl . list /Users UniqueID | awk '{print $2}' | sort -ug | tail -1");
                 $maxid = $maxid + 1;
                 $this->processProvider->executeSudoCommand('dscl . create /Users/' . $userName);
                 if (file_exists("/usr/local/bin/bash")){


### PR DESCRIPTION
https://wiki.php.net/rfc/invalid_strings_in_arithmetic

As of PHP 7.1 this will be needed.