### PR TITLE
apache config files per environment

### DIFF
--- a/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
+++ b/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
@@ -329,10 +329,15 @@ class WebserverSkeleton extends AbstractSkeleton
      */
     private function processConfigFiles(\ArrayObject $project, $configs)
     {
+        $env = 'local';
+        if (array_key_exists('env', $this->app['config'])) {
+            $env = $this->app['config']['env'];
+        }
+
         $ignoreList = array();
         foreach ($configs as $config) {
             /** @var SplFileInfo $config */
-            if ($config->getExtension() == "local") {
+            if ($config->getExtension() == $env) {
                 $ignoreList[] = $config->getBasename('.' . $config->getExtension());
             }
         }
@@ -356,8 +361,8 @@ class WebserverSkeleton extends AbstractSkeleton
                 $realPath = $config->getRealPath();
                 $content = file_get_contents($realPath);
             }
-            if ($config->getExtension() != "local" && in_array($config->getBasename('.'. $config->getExtension()),$ignoreList)){
-                $configcontent .= "\n#SKIPPED " . $realPath . " because there was a .local file\n\n";
+            if ($config->getExtension() != $env && in_array($config->getBasename('.'. $config->getExtension()),$ignoreList)){
+                $configcontent .= "\n#SKIPPED " . $realPath . " because there was a ." . $env . " file\n\n";
             } else {
                 $configcontent .= "\n#BEGIN " . $realPath . "\n\n";
                 $configcontent .= $this->projectConfigProvider->searchReplacer($content, $project) . "\n";


### PR DESCRIPTION
When adding the env variable to your skylab.yml config you can create apache config files per environment.

E.g. In skylab/config/apache.d config dir you create 07envs.prod, 07envs.staging and 07envs.dev.
When you run skylab and you have env: dev in your skylab.yml configuration the 07envs.dev file will be included in the apache config. If you have env: staging, the staging one will be used.

If you don't configure the env variable in your skylab.yml configuraiton file, it will keep on working with .local files.