### PR TITLE
ssl config throw error if no config found

### DIFF
--- a/src/Kunstmaan/Skylab/Provider/ProjectConfigProvider.php
+++ b/src/Kunstmaan/Skylab/Provider/ProjectConfigProvider.php
@@ -354,7 +354,7 @@ class ProjectConfigProvider extends AbstractProvider
         }
 
         if (!$foundSslConfig) {
-            $this->dialogProvider->logWarning("No SSL config found for project ". $config["name"] . "!");
+            $this->dialogProvider->logError("No SSL config found for project ". $config["name"] . " for env " . $this->app["config"]["env"] ."!");
         }
     }
 


### PR DESCRIPTION
if no sslconfig is found, throw an error instead of logging a warning.