### PR TITLE
cleanup don't fail if file does not exist

### DIFF
--- a/templates/execute/snippets/cleanup.yml
+++ b/templates/execute/snippets/cleanup.yml
@@ -1,3 +1,3 @@
 steps:
   - ssh %deploy_server% -p %deploy_port% 'COUNT_BUILDS=$(readlink -f /home/projects/%deploy_project%/data/current/ > /tmp/%deploy_project%-current; ls -1dt /home/projects/%deploy_project%/data/builds/* | grep -v -f /tmp/%deploy_project%-current | grep -v rsync | wc -l); if [ $COUNT_BUILDS -ge 3 ]; then ls -1dt /home/projects/%deploy_project%/data/builds/* | grep -v -f /tmp/%deploy_project%-current | grep -v rsync | tail -n +3 | sudo xargs nice -n 19 rm -rf; fi;'
-  - rm %shared_package_target%
+  - rm -f %shared_package_target%

--- a/templates/execute/snippets/transmit.yml
+++ b/templates/execute/snippets/transmit.yml
@@ -9,6 +9,6 @@ steps:
   - ssh %deploy_server% -p %deploy_port% "sudo setfacl -R -m u:%deploy_project%:rwX /home/projects/%deploy_project%/data/builds/"
   - ssh %deploy_server% -p %deploy_port% "if id -u postgres > /dev/null 2>&1; then sudo setfacl -R -m u:postgres:r-X /home/projects/%deploy_project%/data/builds/; fi"
   - ssh %deploy_server% -p %deploy_port% "sudo setfacl -R -m group:admin:rwX /home/projects/%deploy_project%/data/builds/"
-  - rsync -qahL --progress --rsh=/usr/bin/ssh -e "ssh -p %deploy_port%" %home%/builds/%job_name%-%buildtag%.tar.gz %deploy_server%:/home/projects/%deploy_project%/data/builds/rsync 
-  - rm %home%/builds/%job_name%-%buildtag%.tar.gz 
-  - ssh %deploy_server% -p %deploy_port% "cp /home/projects/%deploy_project%/data/builds/rsync /home/projects/%deploy_project%/data/builds/%job_name%-%buildtag%.tar.gz" 
+  - rsync -qahL --progress --rsh=/usr/bin/ssh -e "ssh -p %deploy_port%" %home%/builds/%job_name%-%buildtag%.tar.gz %deploy_server%:/home/projects/%deploy_project%/data/builds/rsync
+  - rm %home%/builds/%job_name%-%buildtag%.tar.gz
+  - ssh %deploy_server% -p %deploy_port% "cp /home/projects/%deploy_project%/data/builds/rsync /home/projects/%deploy_project%/data/builds/%job_name%-%buildtag%.tar.gz"


### PR DESCRIPTION
added the -f option to the rm in cleanup.yml so it will not throw an error if the file does not exists.
And removed weird chars at the end of three lines in transmit.yml