### PR TITLE
Make it able to override php config files

### DIFF
--- a/src/Kunstmaan/Skylab/Provider/FileSystemProvider.php
+++ b/src/Kunstmaan/Skylab/Provider/FileSystemProvider.php
@@ -191,44 +191,31 @@ class FileSystemProvider extends AbstractProvider
 
     /**
      * @param  \ArrayObject $project
+     * @param  string $type
      * @return array
      */
-    public function getProjectApacheConfigs(\ArrayObject $project)
+    public function getProjectConfigs(\ArrayObject $project, $type)
     {
-        $finder = new Finder();
-        $finder->files()
-            ->sortByName()
-            ->in($this->getProjectConfigDirectory($project["name"]) . "/apache.d/")
-            ->ignoreVCS(true)
-            ->ignoreDotFiles(true)
-            ->notName("*~")
-            ->notName("*.swp")
-            ->notName("*.bak")
-            ->notName("*-")
-            ->depth('== 0');
+        try {
+            $finder = new Finder();
+            $finder->files()
+                ->sortByName()
+                ->in(sprintf('%s/%s', $this->getProjectConfigDirectory($project["name"]), $type))
+                ->ignoreVCS(true)
+                ->ignoreDotFiles(true)
+                ->notName("*~")
+                ->notName("*.swp")
+                ->notName("*.bak")
+                ->notName("*-")
+                ->depth('== 0');
 
-        return iterator_to_array($finder);
-    }
+            return iterator_to_array($finder);
+        }
+        catch (\InvalidArgumentException $e) {
+            $this->dialogProvider->logNotice('Project has no ' . $type . ' config files.');
+        }
 
-    /**
-     * @param  \ArrayObject $project
-     * @return array
-     */
-    public function getProjectNginxConfigs(\ArrayObject $project)
-    {
-        $finder = new Finder();
-        $finder->files()
-            ->sortByName()
-            ->in($this->getProjectConfigDirectory($project["name"]) . "/nginx.d/")
-            ->ignoreVCS(true)
-            ->ignoreDotFiles(true)
-            ->notName("*~")
-            ->notName("*.swp")
-            ->notName("*.bak")
-            ->notName("*-")
-            ->depth('== 0');
-
-        return iterator_to_array($finder);
+        return array();
     }
 
     /**

--- a/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
+++ b/src/Kunstmaan/Skylab/Skeleton/WebserverSkeleton.php
@@ -413,7 +413,7 @@ class WebserverSkeleton extends AbstractSkeleton
         if ($finder->count() == 0) {
             $this->fileSystemProvider->writeProtectedFile($this->fileSystemProvider->getProjectConfigDirectory($project["name"]) . "/nginx.d/05servername", $serverName);
         }
-        $configcontent = $this->processConfigFiles($project, $this->fileSystemProvider->getProjectNginxConfigs($project));
+        $configcontent = $this->processConfigFiles($project, $this->fileSystemProvider->getProjectConfigs($project, 'nginx.d'));
         $this->fileSystemProvider->writeProtectedFile($this->app["config"]["nginx"]["sitesavailable"] . "/" . $project["name"] . ".conf", $configcontent);
     }
 
@@ -430,7 +430,7 @@ class WebserverSkeleton extends AbstractSkeleton
         } else {
             $this->processProvider->executeSudoCommand("rm -f " . $this->fileSystemProvider->getProjectConfigDirectory($project["name"]) . "/apache.d/06devmode");
         }
-        $configcontent = $this->processConfigFiles($project, $this->fileSystemProvider->getProjectApacheConfigs($project));
+        $configcontent = $this->processConfigFiles($project, $this->fileSystemProvider->getProjectConfigs($project, 'apache.d'));
         if ($this->app["config"]["develmode"]) {
             $configcontent = str_replace("-Indexes", "+Indexes", $configcontent);
         }


### PR DESCRIPTION
To be able to override php-fpm config files per project, a php.d folder can now be created in your skylab project config directory. A php-fpm.conf.twig file can be created here and will override the default php-fpm configuration.